### PR TITLE
Per-IO Adapters

### DIFF
--- a/examples/basic_control.rb
+++ b/examples/basic_control.rb
@@ -16,7 +16,7 @@ class StepMash < Brewby::Application
   end
 end
 
-application = StepMash.new adapter: 'test', inputs: [{}], outputs: [{}]
+application = StepMash.new inputs: [{}], outputs: [{}]
 application.add_step :temp_control, target: 125.0, duration: 15
 application.add_step :temp_control, target: 155.0, duration: 35
 application.add_step :temp_control, target: 168.0, duration: 10

--- a/examples/config.json
+++ b/examples/config.json
@@ -1,19 +1,26 @@
 {
-  "adapter":"raspberry_pi",
   "inputs":[
     {
+      "name":"hlt",
+      "adapter":"ds18b20",
       "hardware_id":"28-something"
     },
     {
+      "name":"bk",
+      "adapter":"ds18b20",
       "hardware_id":"28-somethingelse"
     }
   ],
   "outputs":[
     {
+      "name":"hlt",
+      "adapter":"gpio",
       "pulse_range":5000,
       "pin":17
     },
     {
+      "name":"bk",
+      "adapter":"gpio",
       "pulse_range":5000,
       "pin":19
     }

--- a/examples/recipe_loader.rb
+++ b/examples/recipe_loader.rb
@@ -17,7 +17,6 @@ class RecipeLoader < Brewby::Application
 end
 
 app = RecipeLoader.new({
-  adapter: 'test', 
   inputs: [{ name: 'hlt' }, { name: 'bk' }], 
   outputs: [{ name: 'hlt' }, { name: 'bk' }]
 })

--- a/lib/brewby/application.rb
+++ b/lib/brewby/application.rb
@@ -11,7 +11,6 @@ module Brewby
     def initialize options = {}
       @options = options
       @steps = []
-      @adapter = options[:adapter].to_sym
       configure_inputs
       configure_outputs
       @ready = false
@@ -21,7 +20,7 @@ module Brewby
       @inputs = []
 
       @options[:inputs].each do |input_options|
-        add_input @adapter, input_options
+        add_input input_options[:adapter].to_sym, input_options
       end
     end
 
@@ -34,7 +33,7 @@ module Brewby
       @outputs = []
       
       @options[:outputs].each do |output_options|
-        add_output @adapter, output_options
+        add_output output_options[:adapter].to_sym, output_options
       end
     end
 

--- a/lib/brewby/inputs.rb
+++ b/lib/brewby/inputs.rb
@@ -7,6 +7,8 @@ module Brewby
       case adapter
       when :test
         Brewby::Inputs::Test
+      when :ds18b20
+        Brewby::Inputs::DS18B20
       else
         Brewby::Inputs::DS18B20
       end

--- a/lib/brewby/outputs.rb
+++ b/lib/brewby/outputs.rb
@@ -7,6 +7,8 @@ module Brewby
       case adapter
       when :test
         Brewby::Outputs::Test
+      when :gpio
+        Brewby::Outputs::GPIO
       else
         Brewby::Outputs::GPIO
       end

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -2,13 +2,19 @@ require 'spec_helper'
 
 describe Brewby::Application do
   before do
-    @output = {
+    @outputs = [{
       pin: 1,
-      pulse_range: 5000
-    }
+      pulse_range: 5000,
+      adapter: :test
+    }]
+
+    @inputs = [
+      { adapter: :test },
+      { adapter: :test, hardware_id: '28-ba1c9d2e48' }
+    ]
 
     Brewby::Application.any_instance.stub(:configure_view)
-    @application = Brewby::Application.new adapter: :test, outputs: [@output], inputs: [{}, {hardware_id: '28-ba1c9d2e48'}]
+    @application = Brewby::Application.new outputs: @outputs, inputs: @inputs
   end
   
   it 'should have one output' do

--- a/spec/step_loader_spec.rb
+++ b/spec/step_loader_spec.rb
@@ -5,9 +5,18 @@ describe Brewby::StepLoader do
     Brewby::Application.any_instance.stub(:render)
     Brewby::Application.any_instance.stub(:configure_view)
 
-    @application = Brewby::Application.new adapter: :test, 
-      outputs: [{ pin: 1, name: :hlt }, { pin: 2, name: :mlt }, { pin: 3, name: :bk }], 
-      inputs: [{ name: :hlt}, { name: :mlt }, { name: :bk }]
+    outputs = [
+      { adapter: :test, pin: 1, name: :hlt },
+      { adapter: :test, pin: 2, name: :mlt },
+      { adapter: :test, pin: 3, name: :bk }
+    ]
+    inputs = [
+      { adapter: :test, name: :hlt},
+      { adapter: :test, name: :mlt },
+      { adapter: :test, name: :bk }
+    ]
+
+    @application = Brewby::Application.new outputs: outputs, inputs: inputs
     @loader = Brewby::StepLoader.new @application
   end
 

--- a/spec/steps/dsl/step_spec.rb
+++ b/spec/steps/dsl/step_spec.rb
@@ -3,20 +3,20 @@ require 'spec_helper'
 describe Brewby::Steps::DSL::Step do
   before do
     @outputs = [
-      { name: :hlt, pin: 3 },
-      { name: :mlt, pin: 2 },
-      { name: :bk, pin: 1 }
+      { adapter: :test, name: :hlt, pin: 3 },
+      { adapter: :test, name: :mlt, pin: 2 },
+      { adapter: :test, name: :bk, pin: 1 }
     ]
 
     @inputs = [
-      { name: :bk },
-      { name: :mlt },
-      { name: :hlt }
+      { adapter: :test, name: :bk },
+      { adapter: :test, name: :mlt },
+      { adapter: :test, name: :hlt }
     ]
 
     Brewby::Application.any_instance.stub(:render)
     Brewby::Application.any_instance.stub(:configure_view)
-    @application = Brewby::Application.new adapter: :test, outputs: @outputs, inputs: @inputs
+    @application = Brewby::Application.new outputs: @outputs, inputs: @inputs
     @step = Brewby::Steps::DSL::Step.new 'Test Step', @application
   end
 


### PR DESCRIPTION
Instead of using a generic adapter and assuming one configuration for the entire setup. Pass
an adapter symbol in the input/output options hash.  This opens up a plethora of configuration
options.
