### PR TITLE
Updates all specs to rspec 3.x style

### DIFF
--- a/lib/brewby/inputs/test.rb
+++ b/lib/brewby/inputs/test.rb
@@ -4,10 +4,15 @@ module Brewby
       attr_accessor :name
       def initialize options = {}
         @name = options[:name]
+        @value = options[:value] || (75 + rand(100)).to_f
+      end
+
+      def set_value value
+        @value = value
       end
 
       def read
-        (75 + rand(100)).to_f
+        @value
       end
     end
   end

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -13,43 +13,54 @@ describe Brewby::Application do
       { adapter: :test, hardware_id: '28-ba1c9d2e48' }
     ]
 
-    Brewby::Application.any_instance.stub(:configure_view)
     @application = Brewby::Application.new outputs: @outputs, inputs: @inputs
   end
-  
+
   it 'should have one output' do
-    @application.outputs.size.should == 1
-    @application.outputs.first.should be_instance_of Brewby::HeatingElement
-    @application.outputs.first.adapter.should be_instance_of Brewby::Outputs::Test
+    expect(@application.outputs.size).to eql 1
+  end
+
+  it "should have a heating element output" do
+    expect(@application.outputs.first).to be_instance_of Brewby::HeatingElement
+  end
+
+  it "should have a test adapter for the heating element" do
+    expect(@application.outputs.first.adapter).to be_instance_of Brewby::Outputs::Test
   end
 
   it 'should have two inputs' do
-    @application.inputs.size.should == 2
+    expect(@application.inputs.size).to eql 2
+  end
+
+  it "should have inputs of type test" do
     @application.inputs.each do |input|
-      input.should be_instance_of Brewby::Inputs::Test
+      expect(input).to be_instance_of Brewby::Inputs::Test
     end
   end
-  
+
 
   context 'adding steps' do
     before do
-      @application.add_step :temp_control, mode: :auto, mode: :auto, target: 155.0, duration: 15
+      @application.add_step :temp_control, mode: :auto, target: 155.0, duration: 15
       @step = @application.steps.first
     end
 
     it 'creates a step object with passed configuration options' do
-      @step.should be_instance_of Brewby::Steps::TempControl
+      expect(@step).to be_instance_of Brewby::Steps::TempControl
     end
 
-    it 'passes an input and an output to the step' do
-      @step.input.should == @application.inputs.first
-      @step.output.should == @application.outputs.first
+    it 'passes an input to the step' do
+      expect(@step.input).to eql @application.inputs.first
+    end
+
+    it "passes an output to the step" do
+      expect(@step.output).to eql @application.outputs.first
     end
 
     it 'allows the step to specify the input/output objects to use' do
-      @application.add_step :temp_control, mode: :auto, mode: :auto, target: 155.0, duration: 15, input: @application.inputs.last
+      @application.add_step :temp_control, mode: :auto, target: 155.0, duration: 15, input: @application.inputs.last
       @step = @application.steps.last
-      @step.input.should == @application.inputs.last
+      expect(@step.input).to eql @application.inputs.last
     end
   end
 end

--- a/spec/heating_element_spec.rb
+++ b/spec/heating_element_spec.rb
@@ -13,32 +13,32 @@ describe Brewby::HeatingElement do
 
   describe 'relay pulsing' do
     it 'turn on the relay when first pulsed' do
-      @element.should be_off
+      expect(@element.off?).to be true
       @element.pulse
-      @element.should be_on
+      expect(@element.off?).to be false
     end
 
     it 'turns on the relay while within pulse width' do
-      @element.should be_off
+      expect(@element.off?).to be true
       @element.instance_variable_set(:@pulse_range_end, millis_from_now(4))
       @element.pulse
-      @element.should be_on
+      expect(@element.on?).to be true
     end
 
     it 'turns off the relay when time exceeds pulse width' do
       @element.instance_variable_set(:@pulse_range_end, millis_from_now(5))
       @element.pulse
-      @element.should be_on
+      expect(@element.on?).to be true
       @element.instance_variable_set(:@pulse_range_end, millis_from_now(1))
       @element.pulse
-      @element.should be_off
+      expect(@element.off?).to be true
     end
-    
+
     it 'turns on the relay when time hits the next pulse range' do
-      @element.should be_off
+      expect(@element.off?).to be true
       @element.instance_variable_set(:@pulse_range_end, millis_from_now(-1))
       @element.pulse
-      @element.should be_on
+      expect(@element.on?).to be true
     end
   end
 end

--- a/spec/inputs/ds18b20_spec.rb
+++ b/spec/inputs/ds18b20_spec.rb
@@ -3,37 +3,37 @@ require 'spec_helper'
 describe Brewby::Inputs::DS18B20 do
   it 'accepts a hardware_id' do
     sensor = Brewby::Inputs::DS18B20.new hardware_id: 'something'
-    sensor.hardware_id.should == 'something'
+    expect(sensor.hardware_id).to eql 'something'
   end
 
   it 'picks the first hardware_id it finds when no hardware_id is specified' do
     Dir.mktmpdir do |dir|
       File.write "#{dir}/28-12345", "1"
       sensor = Brewby::Inputs::DS18B20.new device_path: dir
-      sensor.hardware_id.should == '28-12345'
+      expect(sensor.hardware_id).to eql '28-12345'
     end
   end
 
   context 'reading sensor data' do
     before do
-      Brewby::Inputs::DS18B20.any_instance.stub(:read_raw) { "f5 00 4b 46 7f ff 0b 10 d7 : crc=d7 YES\nf5 00 4b 46 7f ff 0b 10 d7 t=15312" }
       @sensor = Brewby::Inputs::DS18B20.new device_path: @device_dir, hardware_id: '28-12345'
+      allow(@sensor).to receive(:read_raw) { "f5 00 4b 46 7f ff 0b 10 d7 : crc=d7 YES\nf5 00 4b 46 7f ff 0b 10 d7 t=15312" }
     end
 
     it 'reads the temperaturee and returns it in fahrenheit' do
       input = @sensor.read
-      input.should == 59.562
+      expect(input).to eql 59.562
     end
 
     it 'parses the raw data to celsius' do
       tempC = @sensor.parse @sensor.read_raw
-      tempC.should == 15.312
+      expect(tempC).to eql 15.312
     end
 
     it 'returns nil when an error occurs when parsing' do
-      Brewby::Inputs::DS18B20.any_instance.stub(:read_raw) { "f5 00 4b 46 7f ff 0b 10 d7 : crc=d7 NO\nf5 00 4b 46 7f ff 0b 10 d7" }
+      allow(@sensor).to receive(:read_raw) { "f5 00 4b 46 7f ff 0b 10 d7 : crc=d7 NO\nf5 00 4b 46 7f ff 0b 10 d7" }
       input = @sensor.read
-      input.should be_nil
+      expect(input).to be nil
     end
   end
 end

--- a/spec/inputs_spec.rb
+++ b/spec/inputs_spec.rb
@@ -1,8 +1,13 @@
 require 'spec_helper'
 
 describe Brewby::Inputs do
-  it 'determines input class based on adapter' do
-    Brewby::Inputs.adapter_class(:test).should == Brewby::Inputs::Test
-    Brewby::Inputs.adapter_class(:raspberry_pi).should == Brewby::Inputs::DS18B20
+  it "returns the DS18B20 as default sensor type for RPi" do
+    input_class = Brewby::Inputs.adapter_class(:raspberry_pi)
+    expect(input_class).to be Brewby::Inputs::DS18B20
+  end
+
+  it "returns the test sensor for test mode" do
+    input_class = Brewby::Inputs.adapter_class(:test)
+    expect(input_class).to be Brewby::Inputs::Test
   end
 end

--- a/spec/outputs/gpio_spec.rb
+++ b/spec/outputs/gpio_spec.rb
@@ -16,20 +16,20 @@ describe Brewby::Outputs::GPIO do
     it 'initializes the GPIO pin via export' do
       Brewby::Outputs::GPIO.new pin: 1, gpio_path: @gpio_dir
       data = File.read "#{@gpio_dir}/export"
-      data.should == '1'
+      expect(data).to eql '1'
     end
 
     it 'initializes the GPIO pin direction' do
       Brewby::Outputs::GPIO.new pin: 1, gpio_path: @gpio_dir
       data = File.read "#{@gpio_dir}/gpio1/direction"
-      data.should == 'out'
+      expect(data).to eql 'out'
     end
 
     it 'does not initialize the GPIO pin if already initialized' do
       File.write "#{@gpio_dir}/gpio1/value", ""
       Brewby::Outputs::GPIO.new pin: 1, gpio_path: @gpio_dir
       data = File.read "#{@gpio_dir}/export"
-      data.should == ''
+      expect(data).to eql ''
     end
   end
 
@@ -45,21 +45,21 @@ describe Brewby::Outputs::GPIO do
 
     it 'sets the pin value to 1 when on' do
       @output.on
-      pin_value.should == '1'
+      expect(pin_value).to eql '1'
     end
 
     it 'sets the pin value to 0 when off' do
       @output.off
-      pin_value.should == '0'
+      expect(pin_value).to eql '0'
     end
 
     it 'returns false when off' do
-      @output.should_not be_on
+      expect(@output.on?).to be false
     end
 
     it 'returns true when on' do
       @output.on
-      @output.should be_on
+      expect(@output.on?).to be true
     end
   end
 end

--- a/spec/outputs_spec.rb
+++ b/spec/outputs_spec.rb
@@ -1,8 +1,18 @@
 require 'spec_helper'
 
 describe Brewby::Outputs do
-  it 'determines output class based on adapter' do
-    Brewby::Outputs.adapter_class(:test).should == Brewby::Outputs::Test
-    Brewby::Outputs.adapter_class(:raspberry_pi).should == Brewby::Outputs::GPIO
+  it "defaults output class to GPIO" do
+    output_class = Brewby::Outputs.adapter_class :default
+    expect(output_class).to be Brewby::Outputs::GPIO
+  end
+
+  it "outputs the RPi to GPIO" do
+    output_class = (Brewby::Outputs.adapter_class(:raspberry_pi))
+    expect(output_class).to be Brewby::Outputs::GPIO
+  end
+
+  it "outputs the test output class when running test" do
+    output_class = Brewby::Outputs.adapter_class(:test)
+    expect(output_class).to be Brewby::Outputs::Test
   end
 end

--- a/spec/step_loader_spec.rb
+++ b/spec/step_loader_spec.rb
@@ -2,9 +2,6 @@ require 'spec_helper'
 
 describe Brewby::StepLoader do
   before do
-    Brewby::Application.any_instance.stub(:render)
-    Brewby::Application.any_instance.stub(:configure_view)
-
     outputs = [
       { adapter: :test, pin: 1, name: :hlt },
       { adapter: :test, pin: 2, name: :mlt },
@@ -22,6 +19,6 @@ describe Brewby::StepLoader do
 
   it 'reads a Brewby process file' do
     @loader.load_file File.join(File.dirname(__FILE__), 'support', 'sample_recipe.rb')
-    @application.should have(4).steps
+    expect(@application.steps.length).to eql 4
   end
 end

--- a/spec/steps/dsl/step_spec.rb
+++ b/spec/steps/dsl/step_spec.rb
@@ -14,32 +14,30 @@ describe Brewby::Steps::DSL::Step do
       { adapter: :test, name: :hlt }
     ]
 
-    Brewby::Application.any_instance.stub(:render)
-    Brewby::Application.any_instance.stub(:configure_view)
     @application = Brewby::Application.new outputs: @outputs, inputs: @inputs
     @step = Brewby::Steps::DSL::Step.new 'Test Step', @application
   end
 
   it 'accepts a type' do
     @step.type :temp_control
-    @step.step_class.should == Brewby::Steps::TempControl
+    expect(@step.step_class).to be Brewby::Steps::TempControl
   end
 
   it 'accepts options on the type' do
     @step.type :temp_control, mode: :auto, target: 155.0, duration: 60
-    @step.options[:mode].should == :auto
-    @step.options[:target].should == 155.0
-    @step.options[:duration].should == 60
+    expect(@step.options[:mode]).to eql :auto
+    expect(@step.options[:target]).to eql 155.0
+    expect(@step.options[:duration]).to eql 60
   end
 
   it 'accepts a mode' do
     @step.mode :manual
-    @step.options[:mode].should == :manual
+    expect(@step.options[:mode]).to eql :manual
   end
 
   it 'accepts a target' do
     @step.target 155.0
-    @step.options[:target].should == 155.0
+    expect(@step.options[:target]).to eql 155.0
   end
 
   context 'creation' do
@@ -51,11 +49,11 @@ describe Brewby::Steps::DSL::Step do
     end
 
     it 'should translate the input correctly' do
-      @created_step.input.name.should == :mlt
+      expect(@created_step.input.name).to eql :mlt
     end
 
     it 'should translate the output correctly' do
-      @created_step.output.name.should == :bk
+      expect(@created_step.output.name).to eql :bk
     end
   end
 end

--- a/spec/steps/temp_control_spec.rb
+++ b/spec/steps/temp_control_spec.rb
@@ -1,61 +1,70 @@
 require 'spec_helper'
 
 describe Brewby::Steps::TempControl do
-  let(:sensor) { Brewby::TempSensor.new 1 }
+  let(:sensor) { Brewby::Inputs::Test.new }
   let(:adapter) { Brewby::Outputs::Test.new }
   let(:element) { Brewby::HeatingElement.new adapter, pulse_width: 5000 }
   let(:step) { Brewby::Steps::TempControl.new mode: :manual, input: sensor, output: element }
 
   it 'configures an input sensor' do
-    step.input.should be_instance_of Brewby::TempSensor
+    expect(step.input).to be_instance_of Brewby::Inputs::Test
   end
 
   it 'configures an output sensor' do
-    step.output.should be_instance_of Brewby::HeatingElement
+    expect(step.output).to be_instance_of Brewby::HeatingElement
   end
 
   context 'automatic temperature control' do
     before do
-      @step = Brewby::Steps::TempControl.new mode: :auto, target: 155.0, 
+      @step = Brewby::Steps::TempControl.new mode: :auto, target: 155.0,
         duration: 15, output: element, input: sensor
     end
 
     it 'configures a PID controller' do
-      @step.pid.should be_instance_of Temper::PID
+      expect(@step.pid).to be_instance_of Temper::PID
     end
 
     it 'sets a target temperature' do
-      @step.target.should == 155.0
-      @step.pid.setpoint.should == 155.0
+      expect(@step.target).to eql 155.0
+    end
+
+    it "sets the pid setpoint to the target" do
+      expect(@step.pid.setpoint).to eql 155.0
     end
 
     it 'sets a temperature hold duration' do
-      @step.duration.should == 15
+      expect(@step.duration).to eql 15
     end
 
     it 'defaults to a 1 minute temperature hold duration' do
       step = Brewby::Steps::TempControl.new mode: :auto, target: 155.0
-      step.duration.should == 1
+      expect(step.duration).to eql 1
     end
 
     it 'returns true for automatic control' do
-      @step.automatic_control?.should be_true
+      expect(@step.automatic_control?).to be true
     end
 
     it 'returns false for manual control' do
-      @step.manual_control?.should be_false
+      expect(@step.manual_control?).to be false
     end
 
     it 'calculates the output level based on PID levels' do
+      @step.input.set_value 1.0
       @step.calculate_power_level
-      @step.power_level.should == 1.0
-      @step.output.pulse_width.should == 5000
+      expect(@step.power_level).to eql 1.0
+    end
+
+    it "sets the pulse width based on the power level" do
+      @step.input.set_value 1.0
+      @step.calculate_power_level
+      expect(@step.output.pulse_width).to eql 5000
     end
 
     it 'does not explode with a faulty input' do
-      @step.stub(:read_input) { nil }
+      @step.input.set_value nil
       @step.calculate_power_level
-      @step.output.pulse_width.should == 0
+      expect(@step.output.pulse_width).to eql 0
     end
   end
 
@@ -65,26 +74,33 @@ describe Brewby::Steps::TempControl do
     end
 
     it 'does not create a PID controller' do
-      @step.pid.should be_nil
+      expect(@step.pid).to be nil
     end
 
     it 'returns true for manual mode' do
-      @step.should be_manual_control
+      expect(@step.manual_control?).to be true
     end
 
     it 'returns false for automatic control' do
-      @step.should_not be_automatic_control
+      expect(@step.automatic_control?).to be false
     end
 
     it 'sets the power level' do
-      @step.power_level.should == 0.85
-      @step.output.pulse_width.should == 4250
+      expect(@step.power_level).to eql 0.85
+    end
+
+    it "maps the pulse width to the power level" do
+      expect(@step.output.pulse_width).to eql 4250
     end
 
     it 'can have the power level set manually' do
       @step.set_power_level 0.75
-      @step.power_level.should == 0.75
-      @step.output.pulse_width.should == 3750
+      expect(@step.power_level).to eql 0.75
+    end
+
+    it "maps the pulse width based on the manual power level" do
+      @step.set_power_level 0.75
+      expect(@step.output.pulse_width).to eql 3750
     end
   end
 
@@ -95,15 +111,20 @@ describe Brewby::Steps::TempControl do
     end
 
     it 'reads sensor input' do
-      @step.input.should_receive(:read) { 115.0 }
-      @step.read_input.should == 115.0
-      @step.last_reading.should == 115.0
+      @step.input.set_value 115.0
+      expect(@step.read_input).to eql 115.0
+    end
+
+    it "sets the last_reading based on sensor input" do
+      @step.input.set_value 115.0
+      @step.read_input
+      expect(@step.last_reading).to eql 115.0
     end
 
     it 'does not set last_reading if sensor input is faulty' do
-      @step.input.stub(:read) { nil }
-      @step.read_input.should be_nil
-      @step.last_reading.should == 0.0
+      @step.input.set_value nil
+      @step.read_input
+      expect(@step.last_reading).to eql 0.0
     end
   end
 
@@ -116,19 +137,19 @@ describe Brewby::Steps::TempControl do
 
       it 'pulses the element' do
         @step.step_iteration
-        @step.output.should be_on
+        expect(@step.output.on?).to be true
       end
 
       it 'takes a sensor reading' do
-        @step.input.stub(:read) { 115.0 }
+        @step.input.set_value 115.0
         @step.step_iteration
-        @step.last_reading.should == 115.0
+        expect(@step.last_reading).to eql 115.0
       end
 
       it 'does not take a sensor reading if input does not exist' do
         @step = Brewby::Steps::TempControl.new mode: :manual, power_level: 0.85, output: element
         @step.step_iteration
-        @step.last_reading.should == 0.0
+        expect(@step.last_reading).to eql 0.0
       end
     end
 
@@ -139,47 +160,47 @@ describe Brewby::Steps::TempControl do
       end
 
       it 'pulses the element' do
-        @step.output.should_receive(:pulse)
         @step.step_iteration
       end
 
       it 'calculates the power level and adjusts the heating element' do
-        @step.pid.stub(:control) { 3000 }
+        #@step.pid.stub(:control) { 3000 }
+        @step.input.set_value 136.0
         @step.step_iteration
-        @step.output.pulse_width.should == 3000
+        expect(@step.output.pulse_width).to eql 3427.0
       end
 
       it 'reads from the sensor and logs to last_reading' do
-        @step.input.stub(:read) { 125.0 }
+        @step.input.set_value 125.0
         @step.step_iteration
-        @step.last_reading.should == 125.0
+        expect(@step.last_reading).to eql 125.0
       end
 
       context 'when temperature threshold is reached' do
         before do
-          @step.input.stub(:read) { 156.0 }
+          @step.input.set_value 156.0
           @step.step_iteration
         end
 
         it 'sets the threshold as true' do
-          @step.threshold_reached.should be_true
+          expect(@step.threshold_reached).to be true
         end
 
         it 'maintains threshold_reached even when temp drops below threshold' do
-          @step.input.stub(:read) { 145.0 }
+          @step.input.set_value 145.0
           @step.step_iteration
-          @step.threshold_reached.should be_true
+          expect(@step.threshold_reached).to be true
         end
 
         it 'starts the clock on time remaining' do
-          (@step.time_remaining > 0).should be_true
-          (@step.time_remaining <= @step.duration_in_seconds).should be_true
+          expect(@step.time_remaining > 0).to be true
+          expect(@step.time_remaining <= @step.duration_in_seconds).to be true
         end
 
         it 'stops the step when temperature has hit target for duration' do
           @step.instance_variable_set(:@step_finishes_at, Time.now.to_i - 10)
           @step.step_iteration
-          @step.should be_ended
+          expect(@step.ended?).to be true
         end
       end
     end

--- a/spec/timed_spec.rb
+++ b/spec/timed_spec.rb
@@ -10,28 +10,28 @@ describe Brewby::Timed do
   end
 
   it 'has a start time' do
-    @step.start_time.should be_nil
+    expect(@step.start_time).to be_nil
   end
 
   it 'has an end time' do
-    @step.end_time.should be_nil
+    expect(@step.end_time).to be_nil
   end
 
   context 'unstarted' do
     it 'is unstarted' do
-      @step.started?.should be_false
+      expect(@step.started?).to be false
     end
 
     it 'is unended' do
-      @step.ended?.should be_false
+      expect(@step.ended?).to be false
     end
 
     it 'is not in progress' do
-      @step.in_progress?.should be_false
+      expect(@step.in_progress?).to be false
     end
-    
+
     it 'has no elapsed time' do
-      @step.elapsed.should == 0
+      expect(@step.elapsed).to eql 0
     end
   end
 
@@ -41,20 +41,20 @@ describe Brewby::Timed do
     end
 
     it 'is started' do
-      @step.started?.should be_true
+      expect(@step.started?).to be true
     end
 
     it 'is not ended' do
-      @step.ended?.should be_false
+      expect(@step.ended?).to be false
     end
 
     it 'is in progress' do
-      @step.in_progress?.should be_true
+      expect(@step.in_progress?).to be true
     end
 
     it 'has an elapsed time' do
       elapsed = Time.now - @step.start_time
-      @step.elapsed.should be_within(1).of(elapsed)
+      expect(@step.elapsed).to be_within(1).of(elapsed)
     end
   end
 
@@ -65,20 +65,20 @@ describe Brewby::Timed do
     end
 
     it 'is started' do
-      @step.started?.should be_true
+      expect(@step.started?).to be true
     end
 
     it 'is ended' do
-      @step.ended?.should be_true
+      expect(@step.ended?).to be true
     end
 
     it 'is not in progress' do
-      @step.in_progress?.should be_false
+      expect(@step.in_progress?).to be false
     end
 
     it 'has an elapsed time' do
       elapsed = @step.end_time - @step.start_time
-      @step.elapsed.should == elapsed
+      expect(@step.elapsed).to eql elapsed
     end
   end
 
@@ -87,11 +87,11 @@ describe Brewby::Timed do
       let(:time_remaining) { 3750 }
 
       it 'gives a formatted timer' do
-        @step.timer_for(time_remaining).should == "01:02:30"
+        expect(@step.timer_for(time_remaining)).to eql "01:02:30"
       end
 
       it 'gives a formatted countdown' do
-        @step.countdown_for(time_remaining).should == "01:02:30"
+        expect(@step.countdown_for(time_remaining)).to eql "01:02:30"
       end
     end
 
@@ -99,11 +99,11 @@ describe Brewby::Timed do
       let(:time_remaining) { -95 }
 
       it 'gives a zeroed counter for timers' do
-        @step.timer_for(time_remaining).should == "00:00:00"
+        expect(@step.timer_for(time_remaining)).to eql "00:00:00"
       end
 
       it 'gives a negative counter countdown' do
-        @step.countdown_for(time_remaining).should == "+00:01:35"
+        expect(@step.countdown_for(time_remaining)).to eql "+00:01:35"
       end
     end
   end


### PR DESCRIPTION
This updates Brewby to use rspec 3.x style expectations, and removes the stubs and mocks used before in favor of some adapter changes.
